### PR TITLE
Overwrite permissions with fixed values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.2.0 (2024-01-07)
+## v0.2.0 (2024-01-08)
 
 - Changed `ReproducibleZipFile` to also overwrite file-system permissions with fixed values. These default to `0o644` (`rw-r--r--`) for files and `0o755` (`rwxr-xr-x`) for directories.
 - Added support for `REPRO_ZIPFILE_FILE_MODE` and `REPRO_ZIPFILE_DIR_MODE` environment variables for overriding the fixed file and directory permission values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.0 (2024-01-07)
+
+- Changed `ReproducibleZipFile` to also overwrite file-system permissions with fixed values. These default to `0o644` (`rw-r--r--`) for files and `0o755` (`rwxr-xr-x`) for directories.
+- Added support for `REPRO_ZIPFILE_FILE_MODE` and `REPRO_ZIPFILE_DIR_MODE` environment variables for overriding the fixed file and directory permission values.
+
 ## v0.1.0 (2023-08-12)
 
 Initial release! 🎉

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ See the next two sections for more details about the replacement metadata values
 
 ### Last-modified timestamps
 
-ZIP archives store the last-modified timestamps of files and directories. `ReproducibleZipFile` will set this to a fixed value. By default, the fixed value is 1980-01-01 0:00 UTC, which is the earliest timestamp that is supported by the ZIP format specifications.
+ZIP archives store the last-modified timestamps of files and directories. `ReproducibleZipFile` will set this to a fixed value. By default, the fixed value is 1980-01-01 00:00 UTC, which is the earliest timestamp that is supported by the ZIP format specifications.
 
-You can customize this value with the `SOURCE_DATE_EPOCH` environment variable. If set, it will be used as the fixed value instead. This should be an integer corresponding to the [Unix epoch time](https://en.wikipedia.org/wiki/Unix_time) of the timestamp you want to set. `SOURCE_DATE_EPOCH` is a [standard](https://reproducible-builds.org/docs/source-date-epoch/) created by the [Reproducible Builds project](https://reproducible-builds.org/) for software distributions.
+You can customize this value with the `SOURCE_DATE_EPOCH` environment variable. If set, it will be used as the fixed value instead. This should be an integer corresponding to the [Unix epoch time](https://en.wikipedia.org/wiki/Unix_time) of the timestamp you want to set, e.g., `1704067230` for 2024-01-01 00:00:00 UTC. `SOURCE_DATE_EPOCH` is a [standard](https://reproducible-builds.org/docs/source-date-epoch/) created by the [Reproducible Builds project](https://reproducible-builds.org/) for software distributions.
 
 ### File-system permissions
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can customize this value with the `SOURCE_DATE_EPOCH` environment variable. 
 
 ### File-system permissions
 
-ZIP archives store the file-system permissions of files and directories. The default permissions set for new files or directories often can be different across different systems or users without any intentional choices being made. (These default permissions are controlled by something called [`umask`](https://en.wikipedia.org/wiki/Umask).) `ReproducibleZipFile` will set these to fixed values. By default, the fixed values are `0o644` (`rw-r--r--`) for files and `0o755` (`rwxr-xr-x`) for directories, which matches the common default `umask` of `0o022` for root users on Unix systems.
+ZIP archives store the file-system permissions of files and directories. The default permissions set for new files or directories often can be different across different systems or users without any intentional choices being made. (These default permissions are controlled by something called [`umask`](https://en.wikipedia.org/wiki/Umask).) `ReproducibleZipFile` will set these to fixed values. By default, the fixed values are `0o644` (`rw-r--r--`) for files and `0o755` (`rwxr-xr-x`) for directories, which matches the common default `umask` of `0o022` for root users on Unix systems. (The [`0o` prefix](https://docs.python.org/3/reference/lexical_analysis.html#integers) is how you can write an octal—i.e., base 8—integer literal in Python.)
 
 You can customize these values using the environment variables `REPRO_ZIPFILE_FILE_MODE` and `REPRO_ZIPFILE_DIR_MODE`. They should be in three-digit octal [Unix numeric notation](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation), e.g., `644` for `rw-r--r--`.
 

--- a/repro_zipfile.py
+++ b/repro_zipfile.py
@@ -75,6 +75,7 @@ class ReproducibleZipFile(ZipFile):
 
         ## repro-zipfile ADDED ##
         # Overwrite date_time and extrnal_attr (permissions mode)
+        zinfo = copy(zinfo)
         zinfo.date_time = date_time()
         if zinfo.is_dir():
             zinfo.external_attr = (0o40000 | dir_mode()) << 16
@@ -125,6 +126,7 @@ class ReproducibleZipFile(ZipFile):
 
         ## repro-zipfile ADDED ##
         # Overwrite date_time and extrnal_attr (permissions mode)
+        zinfo = copy(zinfo)
         zinfo.date_time = date_time()
         if zinfo.is_dir():
             zinfo.external_attr = (0o40000 | dir_mode()) << 16
@@ -175,6 +177,7 @@ class ReproducibleZipFile(ZipFile):
 
             ## repro-zipfile ADDED ##
             # Overwrite date_time and extrnal_attr (permissions mode)
+            zinfo = copy(zinfo)
             zinfo.date_time = date_time()
             if zinfo.is_dir():
                 zinfo.external_attr = (0o40000 | dir_mode()) << 16

--- a/repro_zipfile.py
+++ b/repro_zipfile.py
@@ -11,23 +11,51 @@ try:
 except ImportError:
     _MASK_COMPRESS_OPTION_1 = 0x02
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
 def date_time() -> Union[time.struct_time, Tuple[int, int, int, int, int, int]]:
+    """Returns date_time value used to force overwrite on all ZipInfo objects. Defaults to
+    1980-01-01 00:00:00. You can set this with the environment variable SOURCE_DATE_EPOCH as an
+    integer value representing seconds since Epoch.
+    """
     source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH", None)
     if source_date_epoch is not None:
         return time.localtime(int(source_date_epoch))
     return (1980, 1, 1, 0, 0, 0)
 
 
+def file_mode() -> int:
+    """Returns the file permissions mode value used to force overwrite on all ZipInfo objects.
+    Defaults to 0o644 (rw-r--r--). You can set this with the environment variable
+    REPRO_ZIPFILE_FILE_MODE as a value in octal (e.g., '644').
+    """
+    file_mode_env = os.environ.get("REPRO_ZIPFILE_FILE_MODE", None)
+    if file_mode_env is not None:
+        return int(file_mode_env, 8)
+    return 0o644
+
+
+def dir_mode() -> int:
+    """Returns the directory permissions mode value used to force overwrite on all ZipInfo objects.
+    Defaults to 0o755 (rwxr-xr-x). You can set this with the environment variable
+    REPRO_ZIPFILE_DIR_MODE You can set this with the environment variable
+    REPRO_ZIPFILE_FILE_MODE as a value in octal (e.g., '755').
+    """
+    dir_mode_env = os.environ.get("REPRO_ZIPFILE_DIR_MODE", None)
+    if dir_mode_env is not None:
+        return int(dir_mode_env, 8)
+    return 0o755
+
+
 class ReproducibleZipFile(ZipFile):
     """Open a ZIP file, where file can be a path to a file (a string), a file-like object or a
     path-like object.
 
-    This is a replacement for the Python standard library zipfile.ZipFile that
-    overwrites file-modified timestamps in write mode in order to create a reproducible ZIP
-    archive. For documentation on use, see the Python documentation for zipfile:
+    This is a replacement for the Python standard library zipfile.ZipFile that overwrites
+    file-modified timestamps and file/directory permissions modes in write mode in order to create
+    a reproducible ZIP archive. Other than overwriting these values, it works the same way as
+    zipfile.ZipFile. For documentation on use, see the Python documentation for zipfile:
     https://docs.python.org/3/library/zipfile.html
     """
 
@@ -44,7 +72,16 @@ class ReproducibleZipFile(ZipFile):
             raise ValueError("Can't write to ZIP archive while an open writing handle exists")
 
         zinfo = ZipInfo.from_file(filename, arcname, strict_timestamps=self._strict_timestamps)
-        zinfo.date_time = date_time()  # ADDED
+
+        ## repro-zipfile ADDED ##
+        # Overwrite date_time and extrnal_attr (permissions mode)
+        zinfo.date_time = date_time()
+        if zinfo.is_dir():
+            zinfo.external_attr = (0o40000 | dir_mode()) << 16
+            zinfo.external_attr |= 0x10  # MS-DOS directory flag
+        else:
+            zinfo.external_attr = file_mode() << 16
+        #########################
 
         if zinfo.is_dir():
             zinfo.compress_size = 0
@@ -75,7 +112,7 @@ class ReproducibleZipFile(ZipFile):
         if isinstance(data, str):
             data = data.encode("utf-8")
         if not isinstance(zinfo_or_arcname, ZipInfo):
-            zinfo = ZipInfo(filename=zinfo_or_arcname, date_time=date_time())  # CHANGED
+            zinfo = ZipInfo(filename=zinfo_or_arcname, date_time=time.localtime(time.time())[:6])
             zinfo.compress_type = self.compression
             zinfo._compresslevel = self.compresslevel
             if zinfo.filename.endswith("/"):
@@ -84,8 +121,17 @@ class ReproducibleZipFile(ZipFile):
             else:
                 zinfo.external_attr = 0o600 << 16  # ?rw-------
         else:
-            zinfo = copy(zinfo_or_arcname)  # CHANGED
-            zinfo.date_time = date_time()  # ADDED
+            zinfo = zinfo_or_arcname
+
+        ## repro-zipfile ADDED ##
+        # Overwrite date_time and extrnal_attr (permissions mode)
+        zinfo.date_time = date_time()
+        if zinfo.is_dir():
+            zinfo.external_attr = (0o40000 | dir_mode()) << 16
+            zinfo.external_attr |= 0x10  # MS-DOS directory flag
+        else:
+            zinfo.external_attr = file_mode() << 16
+        #########################
 
         if not self.fp:
             raise ValueError("Attempt to write to ZIP archive that was already closed")
@@ -126,6 +172,16 @@ class ReproducibleZipFile(ZipFile):
                 zinfo.external_attr |= 0x10
             else:
                 raise TypeError("Expected type str or ZipInfo")
+
+            ## repro-zipfile ADDED ##
+            # Overwrite date_time and extrnal_attr (permissions mode)
+            zinfo.date_time = date_time()
+            if zinfo.is_dir():
+                zinfo.external_attr = (0o40000 | dir_mode()) << 16
+                zinfo.external_attr |= 0x10  # MS-DOS directory flag
+            else:
+                zinfo.external_attr = file_mode() << 16
+            #########################
 
             with self._lock:
                 if self._seekable:

--- a/repro_zipfile.py
+++ b/repro_zipfile.py
@@ -153,7 +153,7 @@ class ReproducibleZipFile(ZipFile):
                 dest.write(data)
 
     if sys.version_info < (3, 11):
-        # Following method copied from Python 3.11
+        # Following method modified from Python 3.11
         # https://github.com/python/cpython/blob/202efe1a3bcd499f3bf17bd953c6d36d47747e78/Lib/zipfile.py#L1837-L1870
         # Copyright Python Software Foundation, licensed under PSF License Version 2
         # See LICENSE file for full license agreement and notice of copyright

--- a/repro_zipfile.py
+++ b/repro_zipfile.py
@@ -28,7 +28,8 @@ def date_time() -> Union[time.struct_time, Tuple[int, int, int, int, int, int]]:
 def file_mode() -> int:
     """Returns the file permissions mode value used to force overwrite on all ZipInfo objects.
     Defaults to 0o644 (rw-r--r--). You can set this with the environment variable
-    REPRO_ZIPFILE_FILE_MODE as a value in octal (e.g., '644').
+    REPRO_ZIPFILE_FILE_MODE. It should be in the Unix standard three-digit octal representation
+    (e.g., '644').
     """
     file_mode_env = os.environ.get("REPRO_ZIPFILE_FILE_MODE", None)
     if file_mode_env is not None:
@@ -39,8 +40,8 @@ def file_mode() -> int:
 def dir_mode() -> int:
     """Returns the directory permissions mode value used to force overwrite on all ZipInfo objects.
     Defaults to 0o755 (rwxr-xr-x). You can set this with the environment variable
-    REPRO_ZIPFILE_DIR_MODE You can set this with the environment variable
-    REPRO_ZIPFILE_FILE_MODE as a value in octal (e.g., '755').
+    REPRO_ZIPFILE_DIR_MODE. It should be in the Unix standard three-digit octal representation
+    (e.g., '755').
     """
     dir_mode_env = os.environ.get("REPRO_ZIPFILE_DIR_MODE", None)
     if dir_mode_env is not None:

--- a/repro_zipfile.py
+++ b/repro_zipfile.py
@@ -180,11 +180,8 @@ class ReproducibleZipFile(ZipFile):
             # Overwrite date_time and extrnal_attr (permissions mode)
             zinfo = copy(zinfo)
             zinfo.date_time = date_time()
-            if zinfo.is_dir():
-                zinfo.external_attr = (0o40000 | dir_mode()) << 16
-                zinfo.external_attr |= 0x10  # MS-DOS directory flag
-            else:
-                zinfo.external_attr = file_mode() << 16
+            zinfo.external_attr = (0o40000 | dir_mode()) << 16
+            zinfo.external_attr |= 0x10  # MS-DOS directory flag
             #########################
 
             with self._lock:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 from time import sleep
-import zipfile
 from zipfile import ZipFile, ZipInfo
 
 from repro_zipfile import ReproducibleZipFile

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,4 @@
+import platform
 from time import sleep
 from zipfile import ZipFile, ZipInfo
 
@@ -100,7 +101,9 @@ def test_write_dir_tree_mode(base_path):
 
     # ReproducibleZipFile hashes should match; ZipFile hashes should not
     assert hash_file(repro_zipfile_arc1) == hash_file(repro_zipfile_arc2)
-    assert hash_file(zipfile_arc1) != hash_file(zipfile_arc2)
+    if platform.system() != "Windows":
+        # Windows doesn't seem to actually make them different
+        assert hash_file(zipfile_arc1) != hash_file(zipfile_arc2)
 
 
 def test_write_dir_tree_string_paths(rel_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
+from contextlib import contextmanager
 import hashlib
+import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
@@ -41,6 +43,14 @@ def dir_tree_factory(parent_dir: Path):
         file_factory(sub_dir)
 
     return root_dir
+
+
+@contextmanager
+def umask(mask: int):
+    """Utility context manager to temporarily set umask to a new value."""
+    old_mask = os.umask(mask)
+    yield mask
+    os.umask(old_mask)
 
 
 def hash_file(path: Path):


### PR DESCRIPTION
Overwrites file-system permissions, stored in `external_attr`, with fixed values.

The default fixed values are `0o644` (`rw-r--r--`) for files and `0o755` (`rwxr-xr-x`) for directories, which matches the common default `umask` of `0o022` for root users on Unix systems. These can be changed with the variables `REPRO_ZIPFILE_FILE_MODE` and `REPRO_ZIPFILE_DIR_MODE`.

Closes #3. 