### PR TITLE
Ensure that the timezone doesn't leak into zips.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — repro-zipfile
 
+## v0.3.1 (2024-02-02)
+
+- Fixed bug that caused timestamps set by `SOURCE_DATE_EPOCH` to be affected by the local system timezone. It now always uses UTC. ([PR #8](https://github.com/drivendataorg/repro-zipfile/pull/8) from [@thatch](https://github.com/thatch))
+
 ## v0.3.0 (2024-01-27)
 
 - Added a `cli` installation extra for installing the rpzip package, which includes a command-line program

--- a/repro_zipfile.py
+++ b/repro_zipfile.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     _MASK_COMPRESS_OPTION_1 = 0x02
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 
 def date_time() -> Union[time.struct_time, Tuple[int, int, int, int, int, int]]:

--- a/repro_zipfile.py
+++ b/repro_zipfile.py
@@ -21,7 +21,7 @@ def date_time() -> Union[time.struct_time, Tuple[int, int, int, int, int, int]]:
     """
     source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH", None)
     if source_date_epoch is not None:
-        return time.localtime(int(source_date_epoch))
+        return time.gmtime(int(source_date_epoch))
     return (1980, 1, 1, 0, 0, 0)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,11 @@
 import platform
-from time import sleep, tzset
+from time import sleep
 from zipfile import ZipFile, ZipInfo
+
+try:
+    from time import tzset
+except ImportError:
+    tzset = None
 
 from repro_zipfile import ReproducibleZipFile
 from tests.utils import (
@@ -195,8 +200,9 @@ def test_write_single_file_source_date_epoch(base_path, monkeypatch):
         zp.write(data_file)
 
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "1691732367")
-    monkeypatch.setenv("TZ", "America/Chicago")
-    tzset()
+    if tzset:
+        monkeypatch.setenv("TZ", "America/Chicago")
+        tzset()
 
     # With SOURCE_DATE_EPOCH set
     arc_sde1 = base_path / "with_sde1.zip"
@@ -205,8 +211,10 @@ def test_write_single_file_source_date_epoch(base_path, monkeypatch):
 
     sleep(2)
     data_file.touch()
-    monkeypatch.setenv("TZ", "America/Los_Angeles")
-    tzset()
+    if tzset:
+        # Set a different timezone to make sure it doesn't affect the set time
+        monkeypatch.setenv("TZ", "America/Los_Angeles")
+        tzset()
 
     arc_sde2 = base_path / "with_sde2.zip"
     with ReproducibleZipFile(arc_sde2, "w") as zp:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,5 @@
 import platform
-from time import sleep
+from time import sleep, tzset
 from zipfile import ZipFile, ZipInfo
 
 from repro_zipfile import ReproducibleZipFile
@@ -195,6 +195,8 @@ def test_write_single_file_source_date_epoch(base_path, monkeypatch):
         zp.write(data_file)
 
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "1691732367")
+    monkeypatch.setenv("TZ", "America/Chicago")
+    tzset()
 
     # With SOURCE_DATE_EPOCH set
     arc_sde1 = base_path / "with_sde1.zip"
@@ -203,6 +205,8 @@ def test_write_single_file_source_date_epoch(base_path, monkeypatch):
 
     sleep(2)
     data_file.touch()
+    monkeypatch.setenv("TZ", "America/Los_Angeles")
+    tzset()
 
     arc_sde2 = base_path / "with_sde2.zip"
     with ReproducibleZipFile(arc_sde2, "w") as zp:


### PR DESCRIPTION
Hello from a fellow connoisseur of zip files.  I saw a new release of this project and wondered how you did it, and found one source of non-deterministic builds in that the system timezone affects how SOURCE_DATE_EPOCH is used.

I'm not able to run the tests on CI in my fork, so I don't know if Windows is passing with this test.  I'm a little concerned that "Availability: Unix" in the docs for time.tzset means the function doesn't even exist, but I'm hoping it does exist and is a no-op.  CI will tell.