### PR TITLE
Use uv; add Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,19 +14,17 @@ jobs:
     name: Code Quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.10"
-          cache: "pip"
-          cache-dependency-path: |
+          enable-cache: true
+          cache-dependency-glob: |
             pyproject.toml
 
       - name: Install hatch
         run: |
-          pip install hatch
+          uv tool install hatch
 
       - name: Lint package
         run: |
@@ -40,28 +38,25 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: |
+          enable-cache: true
+          cache-dependency-glob: |
             pyproject.toml
 
       - name: Install hatch
         run: |
-          pip install hatch
+          uv tool install hatch
 
       - name: Install zip on Windows
         if: matrix.os == 'windows-latest'
         run: |
           choco install zip
-
 
       - name: Run tests
         run: |
@@ -72,7 +67,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ (github.event_name == 'push' && true) || (github.event_name == 'pull_request' && true) || false }}
         if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Build distribution and test installation
@@ -98,7 +93,7 @@ jobs:
   notify:
     name: Notify failed build
     needs: [code-quality, tests]
-    if: failure() && github.event.pull_request == null
+    if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
     steps:
       - uses: jayqi/failed-build-issue-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: System :: Archiving",
   "Topic :: System :: Archiving :: Compression",
   "Topic :: System :: Archiving :: Packaging",
@@ -43,6 +44,7 @@ path = "repro_zipfile.py"
 ## DEFAULT ENVIRONMENT ##
 
 [tool.hatch.envs.default]
+installer = "uv"
 pre-install-commands = [
   "pip install -e . -e cli",
 ]
@@ -59,18 +61,19 @@ typecheck = ["mypy {args:repro_zipfile.py cli/rpzip.py} --install-types --non-in
 ## TESTS ENVIRONMENT ##
 
 [tool.hatch.envs.tests]
+installer = "uv"
 pre-install-commands = [
-  "pip install -e . -e cli",
+  "uv pip install -e . -e cli",
 ]
 features = ["tests", "cli"]
 dependencies = ["coverage>=6.5", "pytest-cov"]
 template = "tests"
 
 [[tool.hatch.envs.tests.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.tests.scripts]
-test = "pytest {args:tests} -v --cov=. --cov=./cli --cov-report=term --cov-report=html --cov-report=xml"
+test = "python -Im pytest {args:tests} -v --cov=. --cov=./cli --cov-report=term --cov-report=html --cov-report=xml"
 
 ## TOOLS ##
 


### PR DESCRIPTION
- Have Hatch use uv as installer
- Add Python 3.13
- Don't notify failed build on `workflow_dispatch`
- Don't fail Codecov for `scheduled` or `workflow_dispatch`